### PR TITLE
Authenticate with an access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Now open vim and run `:WriteAsAuth`
 ```VimScript
 :WriteAsAuth
 Username: janedoe
-Enter password: *******
+Password: *******
 Success. Add to .vimrc:
 let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 ```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Plugin 'internationa1/write-as.vim'
 Then, add this somewhere into your *.vimrc*:
 
 ```VimScript
-" Writeas User Info
-let g:writeas_u = 'YOUR_USERNAME'
+" Writeas Blog Info
 let g:writeas_b = 'YOUR BLOG'
 ```
 
@@ -26,6 +25,7 @@ Now open vim and run `:WriteAsAuth`
 
 ```VimScript
 :WriteAsAuth
+Username: janedoe
 Enter password: *******
 Success. Add to .vimrc:
 let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
@@ -34,6 +34,8 @@ let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 And add that line to your *.vimrc*:
 
 ```VimScript
+" Writeas Blog Info
+let g:writeas_b = 'YOUR BLOG'
 let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ let g:writeas_b = 'YOUR BLOG'
 let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 ```
 
+**Optionally** you can supply your username and password, instead.
+
+```VimScript
+" Writeas User Info
+let g:writeas_u = 'YOUR_USERNAME'
+let g:writeas_p = 'YOUR_PASSWORD'
+let g:writeas_b = 'YOUR BLOG'
+```
+
 # Usage
 
 Make sure you're in the buffer that you intend to upload as a blog post.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,22 @@ Then, add this somewhere into your *.vimrc*:
 ```VimScript
 " Writeas User Info
 let g:writeas_u = 'YOUR_USERNAME'
-let g:writeas_p = 'YOUR_PASSWORD'
 let g:writeas_b = 'YOUR BLOG'
+```
+
+Now open vim and run `:WriteAsAuth`
+
+```VimScript
+:WriteAsAuth
+Enter password: *******
+Success. Add to .vimrc:
+let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+```
+
+And add that line to your *.vimrc*:
+
+```VimScript
+let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 ```
 
 # Usage

--- a/doc/writeas-vim.md
+++ b/doc/writeas-vim.md
@@ -15,6 +15,31 @@ Plugin 'internationa1/write-as.vim'
 Then, add this somewhere into your *.vimrc*:
 
 ```VimScript
+" Writeas Blog Info
+let g:writeas_b = 'YOUR BLOG'
+```
+
+Now open vim and run `:WriteAsAuth`
+
+```VimScript
+:WriteAsAuth
+Username: janedoe
+Password: *******
+Success. Add to .vimrc:
+let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+```
+
+And add that line to your *.vimrc*:
+
+```VimScript
+" Writeas Blog Info
+let g:writeas_b = 'YOUR BLOG'
+let g:writeas_t = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+```
+
+**Optionally** you can supply your username and password, instead.
+
+```VimScript
 " Writeas User Info
 let g:writeas_u = 'YOUR_USERNAME'
 let g:writeas_p = 'YOUR_PASSWORD'

--- a/plugin/writeas-vim.vim
+++ b/plugin/writeas-vim.vim
@@ -20,6 +20,24 @@ user = vim.eval("g:writeas_u")
 pword = vim.eval("g:writeas_p")
 blog = vim.eval("g:writeas_b")
 
+def _authenticate():
+    vim.command("let g:writeas_p = inputsecret('Enter password: ')")
+    pword = vim.eval('g:writeas_p')
+    print('...')
+
+    # Authenticate User
+    url = "https://write.as/api/auth/login"
+    payload = {"alias": user, "pass": pword}
+    auth = rq.post(url, json=payload)  # Authentication request
+    response = auth.json()  # Interpret JSON response
+    if response['code'] != 200:
+        print(response['error_msg'])
+        quit()
+    else:
+        token = response['data']['access_token']
+        print("Authenticated. Add to .vimrc:")
+        print("let g:writeas_t = '{}'".format(token))
+
 def _anonpost(title):
 
     # Authenticate User
@@ -82,7 +100,9 @@ EOF
 if has('python')
         command! -nargs=1 AnonPost :python _anonpost(<f-args>)
         command! -nargs=1 BlogPost :python _blogpost(<f-args>)
+        command! -nargs=0 WriteAsAuth :python _authenticate(<f-args>)
 elseif has('python3')
         command! -nargs=1 AnonPost :python3 _anonpost(<f-args>)
         command! -nargs=1 BlogPost :python3 _blogpost(<f-args>)
+        command! -nargs=0 WriteAsAuth :python3 _authenticate(<f-args>)
 endif

--- a/plugin/writeas-vim.vim
+++ b/plugin/writeas-vim.vim
@@ -47,7 +47,7 @@ def _authenticate(outputToken):
         password = pword
         print("Authenticating...")
     except NameError:
-        vim.command("let g:writeas_p = inputsecret('Enter password: ')")
+        vim.command("let g:writeas_p = inputsecret('Password: ')")
         password = vim.eval('g:writeas_p')
         print('...')
 

--- a/plugin/writeas-vim.vim
+++ b/plugin/writeas-vim.vim
@@ -16,7 +16,10 @@ v = vim
 rq = requests 
 
 #Define Variables
-user = vim.eval("g:writeas_u")
+try:
+    user = vim.eval("g:writeas_u")
+except:
+    pass
 try:
     pword = vim.eval("g:writeas_p")
 except:
@@ -29,10 +32,19 @@ except:
 
 def _authenticate(outputToken):
 
+    # Prompt for username if necessary
+    try:
+        user
+        username = user
+    except NameError:
+        vim.command("let g:writeas_u = input('Username: ')")
+        username = vim.eval('g:writeas_u')
+
     # Prompt for password if necessary
     try:
         pword
         password = pword
+        print("Authenticating...")
     except NameError:
         vim.command("let g:writeas_p = inputsecret('Enter password: ')")
         password = vim.eval('g:writeas_p')
@@ -40,7 +52,7 @@ def _authenticate(outputToken):
 
     # Authenticate User
     url = "https://write.as/api/auth/login"
-    payload = {"alias": user, "pass": password}
+    payload = {"alias": username, "pass": password}
     auth = rq.post(url, json=payload)  # Authentication request
     response = auth.json()  # Interpret JSON response
     if response['code'] != 200:

--- a/plugin/writeas-vim.vim
+++ b/plugin/writeas-vim.vim
@@ -39,6 +39,7 @@ def _authenticate(outputToken):
     except NameError:
         vim.command("let g:writeas_u = input('Username: ')")
         username = vim.eval('g:writeas_u')
+        vim.command("echo '\r'")
 
     # Prompt for password if necessary
     try:


### PR DESCRIPTION
This supports authentication via access token (instead of username and password), so users don't need to store their password in plaintext in their .vimrc if they don't want. It maintains backwards-compatibility with any current config, but adds a new `:WriteAsAuth` command that fetches a Write.as access token users can store in their *.vimrc*. This keeps their password more secure, and has the benefit of speeding up publishing, as authentication is a time-consuming operation.

These changes also let users avoid storing _any_ authentication information in .vimrc and just enter their username and password on the fly when publishing.

I'm not experienced with Vim plugins or Python, but I used vim's `input` and `inputsecret` functions for getting user input. Not sure if there's a better way to do that -- but feel free to improve in any way!